### PR TITLE
Replace Ruby Sass with Dart Sass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:12-buster
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y ruby ruby-dev optipng libjpeg-turbo-progs guetzli && \
+    apt-get install --no-install-recommends -y optipng libjpeg-turbo-progs guetzli && \
     rm -r /var/lib/apt/lists/*
 
-RUN gem install sass
+RUN yarn global add --prefix=/usr/local sass


### PR DESCRIPTION
Ruby Sass is EOL and Dart is the implementation recommended by the
install page.

Link: https://sass-lang.com/install